### PR TITLE
Treat 0 records found as normal

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -51,4 +51,4 @@ doc.search('.result').each do |result|
   end
 end
 
-raise "No records found." unless found
+puts "No records found." unless found


### PR DESCRIPTION
Right now, there are no records lodged this week - it'll happen at the very start of the week pretty much.

This should just be normal termination, rather than an error.